### PR TITLE
Reduce allocations using unique identifiers of keys as keys in the map

### DIFF
--- a/opam
+++ b/opam
@@ -7,7 +7,7 @@ license: "ISC"
 dev-repo: "http://erratique.ch/repos/hmap.git"
 bug-reports: "http://github.com/dbuenzli/hmap/issues"
 tags: ["data-structure" "org:erratique"]
-available: [ ocaml-version >= "4.02.0"]
+available: [ ocaml-version >= "4.08.0"]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}


### PR DESCRIPTION
Following the recent inclusion in the stdlib (as part of the new Type module) of `Type.Id.uid`, it looks like we can always compute a unique integer for type ids.
This PR proposes to use this function to: 1) avoid computing `uid`s separately and storing them along type ids; 2) index the underlying map with uids instead of indexing it using keys (that then need to be boxed).
I think this should avoid the allocations mentioned in issue #2, although using a different approach than what is suggested there?